### PR TITLE
Update Maker of K-S2 to Ricoh Imaging.

### DIFF
--- a/src/aliceVision/sensorDB/cameraSensors.db
+++ b/src/aliceVision/sensorDB/cameraSensors.db
@@ -4779,7 +4779,7 @@ Pentax;Pentax K-70;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Pentax;Pentax K-m;23.5;dpreview,digicamdb
 Pentax;Pentax K-r;23.6;dpreview,digicamdb,imaging-resource
 Pentax;Pentax K-S1;23.5;dpreview,digicamdb,imaging-resource,dxomark
-Pentax;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
+RICOH IMAGING COMPANY, LTD.;Pentax K-S2;23.5;dpreview,digicamdb,imaging-resource,dxomark
 Pentax;Pentax K-x;23.6;dpreview,digicamdb,imaging-resource
 Pentax;Pentax K100D;23.5;dpreview,digicamdb
 Pentax;Pentax K100D Super;23.5;dpreview,digicamdb


### PR DESCRIPTION
Updated cameraSensors.db. I found Actual Metadata of the Maker of K-S2 was RICOH IMAGING COMPANY, LTD. So I updated the corresponding line.

Maker value of newer Models of PENTAX must be same as K-S2, but I can't verify because I don't have them.
Also, Once maker of PENTAX cameras was HOYA corporation(since 2008) and later PENTAX RICOH IMAGING COMPANY, LTD.(since 2011) so I suppose models made in that period may have other metadata value of maker but I'm not sure.